### PR TITLE
Fix typo in Docker command for Hermes-Agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ To get access to the `hermes` command line (for configuration, update, etc):
 
 ```bash
 # From unraid host shell
-docker exec --user 99:100 -it HermesAgent bash
+docker exec --user 99:100 -it Hermes-Agent bash
 
 # Within container
 source .venv/bin/activate


### PR DESCRIPTION
Documentation referenced:
docker exec --user 99:100 -it HermesAgent bash
but docker container appears to be named Hermes-Agent

I believe the package may have changed names. If this was something unique to my setup feel free to reject.